### PR TITLE
Fix: typos in README.md and argparse.hpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ github legacy:
 ```cpp-argparse-dev``` [AUR](https://aur.archlinux.org/packages/cpp-argparse-dev)
 
 ```cpp-argparse-dev``` [MacPorts](https://ports.macports.org/port/cpp-argparse-dev)
-## Available macroses:
-### Can be setted
+## Available macros:
+### Can be set
 ```ARGPARSE_NO_AUTODETECT``` - If you don't want to use terminal size auto-detection feature (for example to avoid using platform specific header files, namely <Windows.h> on OS Windows)
 
 ```ARGPARSE_TAB_SIZE``` - By default, RawDescriptionHelpFormatter and RawTextHelpFormatter replaces tab with 4 spaces expand. You can change amount of expanding spaces.

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -82,7 +82,7 @@
 #define ARGPARSE_VERSION_AT_LEAST(X, Y, Z) \
     (ARGPARSE_VERSION_COMPILED >= ARGPARSE_VERSION_NUM(X, Y, Z))
 
-// compability for version 1.4.0 - 1.6.6
+// compatibility for version 1.4.0 - 1.6.6
 // will be removed in the next minor release (v1.7.0)
 #define _ARGPARSE_VERSION_MAJOR ARGPARSE_VERSION_MAJOR
 #define _ARGPARSE_VERSION_MINOR ARGPARSE_VERSION_MINOR
@@ -2496,7 +2496,7 @@ _check_type_name(Value<std::string> const& expected,
                  std::string const& received)
 {
     if (expected.has_value() && !_is_type_name_correct(expected(), received)) {
-        throw TypeError("type_name missmatch: expected '" + expected() + "'"
+        throw TypeError("type_name mismatch: expected '" + expected() + "'"
                         + ", received '" + received + "'");
     }
 }


### PR DESCRIPTION
merging this should successfully close #11 