### PR TITLE
Add: bash completion functions for ArgumentParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,9 @@ Legacy GitHub workflows:
   - [ArgumentParser objects](#argumentparser-objects-support)
   - [add_argument(name or flags) method](#the-add_argumentname-or-flags-method-support)
   - [add_argument() actions](#the-add_argument-actions-support)
-- [Self test](#self-test)
+- Utils:
+  - [Bash completion](#bash-completion)
+  - [Self test](#self-test)
 - [Execute unit tests](#execute-unit-tests)
 - [License](#license)
 
@@ -652,6 +654,17 @@ epilog
 - [x] "version" - This expects a version= keyword argument in the add_argument() call, and prints version information and exits when invoked.
 - [x] "extend" - This stores a list, and extends each argument value to the list.
 - [x] argparse::BooleanOptionalAction - Adds support for boolean actions such as --foo and --no-foo
+## Bash completion
+ArgumentParser can help you to create bash completion file for your program (this function is experimental):
+```cpp
+std::ofstream file;
+file.open("path-to-script.sh", std::ios::trunc);
+parser.print_bash_completion(file);
+```
+and add to your ```.bashrc``` file:
+```sh
+. path-to-script.sh
+```
 ## Self test
 You can check that you parser is created correctly by calling the ```self_test``` function.
 ```cpp

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -9705,6 +9705,42 @@ public:
     }
 
     /*!
+     *  \brief Print a bash completion to output stream (default: std::cout).
+     *  Copy the contents to ~/.bashrc or create a script file and use it
+     *
+     *  \param os Output stream
+     *
+     *  \since v1.7.2
+     */
+    inline void print_bash_completion(std::ostream& os = std::cout) const
+    {
+        pArguments const optional = m_data->get_optional(false, true);
+        pArguments const positional = m_data->get_positional(false, true);
+        std::vector<std::string> opt;
+        for (std::size_t i = 0; i < optional.size(); ++i) {
+            detail::_insert_vector_to_end(optional.at(i)->flags(), opt);
+        }
+        std::vector<std::string> pos;
+        for (std::size_t i = 0; i < positional.size(); ++i) {
+            detail::_insert_vector_to_end(positional.at(i)->flags(), pos);
+        }
+        if (m_subparsers) {
+            //m_subparsers->parser_names();
+        }
+        if (!opt.empty() || !pos.empty()) {
+            os << "complete";
+            if (!pos.empty()) {
+                os << " -f";
+            }
+            if (!opt.empty()) {
+                os << " -W \"" << detail::_vector_to_string(opt) << "\"";
+            }
+            os << " " << prog();
+            os << std::endl;
+        }
+    }
+
+    /*!
      *  \brief Print a program usage to output stream (default: std::cout)
      *
      *  \param os Output stream
@@ -9829,6 +9865,24 @@ public:
                     m_formatter_class,
                     despecify(detail::_tr(m_epilog, lang)),
                     width, os);
+    }
+
+    /*!
+     *  \brief Return a string containing a bash completion.
+     *  Copy the contents to ~/.bashrc or create a script file and use it
+     *
+     *  \param lang Language value
+     *
+     *  \since v1.7.2
+     *
+     *  \return Bash completion
+     */
+    inline std::string
+    format_bash_completion() const
+    {
+        std::stringstream ss;
+        print_bash_completion(ss);
+        return detail::_trim_copy(ss.str());
     }
 
     /*!

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -9748,6 +9748,10 @@ public:
             }
             min_args += min_amount;
         }
+        if (m_subparsers) {
+            detail::_insert_vector_to_end(
+                        m_subparsers->parser_names(), options);
+        }
         bool have_positional = more_args || min_args != 0 || one_args != 0;
         if (!options.empty() || have_positional) {
             os << "complete";

--- a/include/argparse/argparse.hpp
+++ b/include/argparse/argparse.hpp
@@ -9716,9 +9716,9 @@ public:
     {
         pArguments const optional = m_data->get_optional(false, true);
         pArguments const positional = m_data->get_positional(false, true);
-        std::vector<std::string> opt;
+        std::vector<std::string> options;
         for (std::size_t i = 0; i < optional.size(); ++i) {
-            detail::_insert_vector_to_end(optional.at(i)->flags(), opt);
+            detail::_insert_vector_to_end(optional.at(i)->flags(), options);
         }
         bool more_args = false;
         std::size_t min_args = 0;
@@ -9749,13 +9749,13 @@ public:
             min_args += min_amount;
         }
         bool have_positional = more_args || min_args != 0 || one_args != 0;
-        if (!opt.empty() || have_positional) {
+        if (!options.empty() || have_positional) {
             os << "complete";
             if (have_positional) {
                 os << " -f";
             }
-            if (!opt.empty()) {
-                os << " -W \"" << detail::_vector_to_string(opt) << "\"";
+            if (!options.empty()) {
+                os << " -W \"" << detail::_vector_to_string(options) << "\"";
             }
             os << " " << prog();
             os << std::endl;


### PR DESCRIPTION
Initial implementation for bash completion generation

Checklist:
- [x] optional flags (--f[TAB] -> --foo)
- [ ] optional flags arguments (--foo [TAB] -> --foo [FILES])
- [x] available arguments (optional flags, positional arguments with store actions [TAB] -> --foo [FILES])
- [ ] choices
- [x] subparsers
- [ ] subparser position (P1 P2 ... S  ...)